### PR TITLE
Fix updating generated image

### DIFF
--- a/Assets/iconicScript.cs
+++ b/Assets/iconicScript.cs
@@ -162,7 +162,6 @@ public class iconicScript : MonoBehaviour {
                     Module.HandlePass();
                     return;
                 }
-                Debug.LogFormat("[Iconic #{0}] Test6", ModuleId);
 
                 Phrase.text = ModulePart;
 


### PR DESCRIPTION
- Instead of grabbing the module list through reflection, it is now grabbed through reading the CS file and parsing the text directly. This means we should always have the correct version regardless of the cache

- The previous sheet is automatically deleted so that Unity will have to create a new .meta file for the new generated sheet.